### PR TITLE
Version 0.2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,12 +2,12 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
     BITS: 64
-    OPENSSL_VERSION: 1_1_1g
+    OPENSSL_VERSION: 1_1_1h
     OPENSSL_DIR: C:\OpenSSL
     CHANNEL: stable
   - TARGET: i686-pc-windows-msvc
     BITS: 32
-    OPENSSL_VERSION: 1_1_1g
+    OPENSSL_VERSION: 1_1_1h
     OPENSSL_DIR: C:\OpenSSL
     CHANNEL: stable 
   RUST_BACKTRACE: full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daas"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["dsietz <davidsietz@yahoo.com>"]
 edition = "2018"
 readme = "README.md"
@@ -28,14 +28,13 @@ maintenance = {status = "actively-developed"}
 env_logger = "0.7"
 futures = "0.3"
 log = "0.4"
-pbd = "0.2"
+pbd = "0.3"
 serde ="1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.7.3"
 openssl = "0.10"
-actix-web = "2.0"
-actix-rt = "1.1"
+actix-web = "3"
 rusoto_core = "0.43"
 rusoto_s3 = "0.43"
 base64 = "0.11"
@@ -51,6 +50,7 @@ features = ["snappy","gzip"]
 url = "2.1.1"
 base64 = "0.11"
 json = "0.12"
+actix-rt = "1.1"
 
 [dev-dependencies.reqwest]
 version = "0.10"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ For software development teams who implement the [Data as a Service (DaaS)](http
 
 Here's whats new in 0.2.0:
 
-We've upgraded to more current versions of our crate's dependencies:
-- actix-web = "3.0"
+1. We've upgraded to more current versions of our crate's dependencies:
+   - actix-web = "3.0"
+2. Added the ability to configure the path of local storage used by the DaaSListener by setting the environment variable `DAAS_LOCAL_STORAGE`. If the environment variable is not set, it uses the system's default temporary path.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,10 @@ For software development teams who implement the [Data as a Service (DaaS)](http
 
 ## What's New
 
-Here's whats new in 0.1.0:
+Here's whats new in 0.2.0:
 
 We've upgraded to more current versions of our crate's dependencies:
-- async-trait = "0.1.31"
-- actix-rt = "1.1"
-- actix-web = "2.0"
-- futures = "0.3"
-- pbd = "0.2"
-- rusoto_core = "0.43"
-- rusoto_s3 = "0.43"
+- actix-web = "3.0"
 
 ## Features
 

--- a/examples/daas-listener.rs
+++ b/examples/daas-listener.rs
@@ -7,9 +7,11 @@ use pbd::dua::middleware::actix::*;
 use pbd::dtc::middleware::actix::*;
 use actix_web::{web, App, HttpServer};
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "warn");
+    // set the environment variable for overwriting the default location for local storage 
+    //std::env::set_var("DAAS_LOCAL_STORAGE", "C:\\tmp");
     env_logger::init();
     
     HttpServer::new(

--- a/src/service/listener.rs
+++ b/src/service/listener.rs
@@ -79,8 +79,7 @@ impl DaaSListener {
         };
 
         // store a local copy so data isn't lost
-        // Issue #23 - https://github.com/dsietz/daas-sdk/issues/23
-        let storage = LocalStorage::new("./tests".to_string());
+        let storage = LocalStorage::new(LocalStorage::get_local_path());
         let doc = match storage.upsert_daas_doc(doc) {
             Ok(d) => {
                 info!("DaaS docoument {} has been successfully upserted.", d.clone()._id);


### PR DESCRIPTION
Here's whats new in 0.2.0:

1. We've upgraded to more current versions of our crate's dependencies:
   - actix-web = "3.0"
2. Added the ability to configure the path of local storage used by the DaaSListener by setting the environment variable `DAAS_LOCAL_STORAGE`. If the environment variable is not set, it uses the system's default temporary path.